### PR TITLE
fix backend middleware

### DIFF
--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -11,14 +11,11 @@ export interface RequestWithUser extends Request {
 }
 
 const protect = async (req: RequestWithUser, res: Response, next: NextFunction) => {
-  const authHeader = req.headers.authorization;
-
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+  const token = req.cookies.token;
+  if (!token) {
     res.status(401).json({ message: 'Not authorized, no token provided' });
     return;
   }
-
-  const token = authHeader.split(' ')[1];
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;


### PR DESCRIPTION
This pull request updates the `protect` middleware in `authMiddleware.ts` to improve token handling by switching from using the `Authorization` header to using cookies for token retrieval.

Authentication middleware changes:

* [`backend/src/middlewares/authMiddleware.ts`](diffhunk://#diff-aba3ce5326434b3ddad94e72a5e8fd0f48c20277f72ab2a7c57e99330192cbbeL14-L22): Modified the `protect` function to retrieve the token from `req.cookies.token` instead of the `Authorization` header. This simplifies token handling and ensures that the token is provided via cookies.